### PR TITLE
Add TERM variable and fix a typo.

### DIFF
--- a/first_run.txt
+++ b/first_run.txt
@@ -21,7 +21,7 @@ you can add this to the settings:
   {
     "terminal.integrated.profiles.linux": {
       "host-bash": {
-        "path": "/usr/bin/flatpak-span",
+        "path": "/usr/bin/flatpak-spawn",
         "args":  ["--host", "bash"]
       }
     },

--- a/first_run.txt
+++ b/first_run.txt
@@ -22,7 +22,7 @@ you can add this to the settings:
     "terminal.integrated.profiles.linux": {
       "host-bash": {
         "path": "/usr/bin/flatpak-spawn",
-        "args":  ["--host", "bash"]
+        "args":  ["--host", "--env=TERM=xterm-256color", "bash"]
       }
     },
     "terminal.integrated.defaultProfile.linux": "host-bash"


### PR DESCRIPTION
Added "TERM=xterm-256color" environment variable for some functions to work.

The instructions to make the Integrated Terminal automatically use the host system's shell had a typo.