### PR TITLE
Suggest non-archived dotnet sdk in first_run.txt

### DIFF
--- a/first_run.txt
+++ b/first_run.txt
@@ -37,17 +37,17 @@ To see what's available:
 
 To get support for additional languages, you have to install SDK extensions, e.g.
 
-  $ flatpak install flathub org.freedesktop.Sdk.Extension.dotnet
+  $ flatpak install flathub org.freedesktop.Sdk.Extension.dotnet9
   $ flatpak install flathub org.freedesktop.Sdk.Extension.golang
 
 To enable selected extensions, set FLATPAK_ENABLE_SDK_EXT environment variable
 to a comma-separated list of extension names (name is ID portion after the last dot):
 
-  $ FLATPAK_ENABLE_SDK_EXT=dotnet,golang flatpak run @FLATPAK_ID@
+  $ FLATPAK_ENABLE_SDK_EXT=dotnet9,golang flatpak run @FLATPAK_ID@
 
 To make this persistent, set the variable via flatpak override:
 
-  $ flatpak override --user @FLATPAK_ID@ --env=FLATPAK_ENABLE_SDK_EXT="dotnet,golang"
+  $ flatpak override --user @FLATPAK_ID@ --env=FLATPAK_ENABLE_SDK_EXT="dotnet9,golang"
 
 You can use
 


### PR DESCRIPTION
`org.freedesktop.Sdk.Extension.dotnet` is archived and hasn't been updated in 5 years.